### PR TITLE
config: fix missing config file on install

### DIFF
--- a/debian/python-registryaggregator.service
+++ b/debian/python-registryaggregator.service
@@ -8,5 +8,6 @@ User=ipstudio
 ExecStart=/usr/bin/nmosregistration
 
 [Install]
-Alias=nmosregistration.service ips-regaggregator.service
+Alias=nmosregistration.service
+Alias=ips-regaggregator.service
 WantedBy=multi-user.target

--- a/etc/ips-regaggregator/config.json
+++ b/etc/ips-regaggregator/config.json
@@ -1,4 +1,0 @@
-{
-    "priority": 100,
-    "https_mode": "disabled"
-}

--- a/lib/systemd/system/nmosregistration.service
+++ b/lib/systemd/system/nmosregistration.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=nmosregistration
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-ExecStart=/usr/bin/nmosregistration

--- a/rpm/registryaggregator.spec
+++ b/rpm/registryaggregator.spec
@@ -46,7 +46,7 @@ install -d -m 0755 %{buildroot}%{_sysconfdir}/ips-regaggregator
 install -D -p -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/ips-regaggregator.service
 
 # Install Apache config file
-install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/httpd/conf.d/ips-apis/ips-api-nmosaggregator.conf
+install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/httpd/conf.d/ips-apis/ips-api-registration.conf
 
 %pre
 getent group ipstudio >/dev/null || groupadd -r ipstudio
@@ -75,14 +75,14 @@ rm -rf %{buildroot}
 %files
 %{_bindir}/nmosregistration
 
-%{_unitdir}/%{name}.service
+%{_unitdir}/ips-regaggregator.service
 
 %{python2_sitelib}/%{module_name}
 %{python2_sitelib}/%{module_name}-%{version}*.egg-info
 
 %defattr(-,ipstudio, ipstudio,-)
 
-%config %{_sysconfdir}/httpd/conf.d/ips-apis/ips-api-nmosaggregator.conf
+%config %{_sysconfdir}/httpd/conf.d/ips-apis/ips-api-registration.conf
 
 %changelog
 * Tue Apr 25 2017 Sam Nicholson <sam.nicholson@bbc.co.uk> - 0.1.0-1

--- a/rpm/registryaggregator.spec
+++ b/rpm/registryaggregator.spec
@@ -41,7 +41,6 @@ Implementation of the registration interface
 
 # Install config file
 install -d -m 0755 %{buildroot}%{_sysconfdir}/ips-regaggregator
-install -D -p -m 0644 etc/ips-regaggregator/config.json %{buildroot}%{_sysconfdir}/ips-regaggregator/config.json
 
 # Install systemd unit file
 install -D -p -m 0644 %{SOURCE2} %{buildroot}%{_unitdir}/ips-regaggregator.service
@@ -82,7 +81,6 @@ rm -rf %{buildroot}
 %{python2_sitelib}/%{module_name}-%{version}*.egg-info
 
 %defattr(-,ipstudio, ipstudio,-)
-%config(noreplace) %{_sysconfdir}/ips-regaggregator/config.json
 
 %config %{_sysconfdir}/httpd/conf.d/ips-apis/ips-api-nmosaggregator.conf
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,56 @@ from __future__ import print_function
 from setuptools import setup
 import os
 import sys
+import json
+from setuptools.command.develop import develop
+from setuptools.command.install import install
+
+
+def create_default_conf():
+    fname = "/etc/ips-regaggregator/config.json"
+    if os.path.isfile(fname):
+        return
+
+    defaultData = {
+        "priority": 100,
+        "https_mode": "disabled"
+    }
+
+    try:
+        try:
+            os.makedirs(os.path.dirname(fname))
+        except OSError as e:
+            if e.errno != os.errno.EEXIST:
+                raise
+            pass
+
+        with open(fname, 'w') as outfile:
+            json.dump(defaultData,
+                      outfile,
+                      sort_keys=True,
+                      indent=4,
+                      separators=(",", ": "))
+    except OSError as e:
+        if e.errno != os.errno.EACCES:
+            raise
+        pass
+        # Default config couldn't be created.
+        # Code will fallback to hardcoded defaults.
+        # This should only happen with un-privileged installs
+
+
+class PostDevelopCommand(develop):
+    """Post-installation for development mode."""
+    def run(self):
+        develop.run(self)
+        create_default_conf()
+
+
+class PostInstallCommand(install):
+    """Post-installation for installation mode."""
+    def run(self):
+        install.run(self)
+        create_default_conf()
 
 
 def is_package(path):
@@ -69,5 +119,9 @@ setup(name="registryaggregator",
       data_files=[
         ('/usr/bin', ['bin/nmosregistration'])
       ],
-      long_description="Provides a service implementing the NMOS Registration API"
+      long_description="Provides a service implementing the NMOS Registration API",
+      cmdclass={
+        'develop': PostDevelopCommand,
+        'install': PostInstallCommand,
+      }
       )


### PR DESCRIPTION
This should address the issue highlighted in https://github.com/bbc/rd-ansible-ips-discovery/pull/4 but requires testing first.

@cnorthwood 