### PR TITLE
Use agents from the apmm-agent group

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 pipeline {
     agent {
-        label "ubuntu&&apmm-slave"
+        label "ubuntu&&apmm-agent"
     }
     options {
         ansiColor('xterm') // Add support for coloured output

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ packages_required = [
 
 setup(
     name="registryaggregator",
-    version="0.8.0",
+    version="0.8.0.post1",
     description="BBC implementation of an AMWA NMOS Registration API",
     url='https://github.com/bbc/nmos-registration',
     author='Peter Brightwell',


### PR DESCRIPTION
Replaces `apmm-slave` with the identical `apmm-agent` to remove problematic terminology.

Makes a post-release version to avoid a conflict when CI attempts upload to PyPI.